### PR TITLE
Add AWS_ENDPOINT_URL property to support non standard s3 service, like Minio

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,6 +35,7 @@ that are otherwise encumbered.
 Signed by git commit adding my legal name and git username:
 
 Written in 2018 by David E. Jones - jonesde
+Written in 2021 by Yao Chunlin - chunlinyao
 
 ===========================================================================
 
@@ -57,4 +58,4 @@ litigation is filed.
 Signed by git commit adding my legal name and git username:
 
 Written in 2018 by David E. Jones - jonesde
-
+Written in 2021 by Yao Chunlin - chunlinyao

--- a/MoquiConf.xml
+++ b/MoquiConf.xml
@@ -11,6 +11,9 @@
     <default-property name="AWS_ACCESS_KEY_ID" value=""/>
     <default-property name="AWS_SECRET_ACCESS_KEY" value=""/>
 
+    <!-- Support non standard s3 service, for example Minio -->
+    <default-property name="AWS_ENDPOINT_URL" value=""/>
+
     <!-- these must be used in pairs, if alias used in a aws3://{bucket}/... then is replaced with name -->
     <!-- only 3 sets here by default, code looks for 1-9 -->
     <default-property name="aws_s3_bucket_alias1" value=""/>

--- a/src/main/groovy/org/moqui/aws/S3ClientToolFactory.groovy
+++ b/src/main/groovy/org/moqui/aws/S3ClientToolFactory.groovy
@@ -13,6 +13,8 @@
  */
 package org.moqui.aws
 
+import com.amazonaws.client.builder.AwsClientBuilder
+import com.amazonaws.regions.Regions
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import groovy.transform.CompileStatic
@@ -48,6 +50,9 @@ class S3ClientToolFactory implements ToolFactory<AmazonS3> {
         String awsRegion = SystemBinding.getPropOrEnv("AWS_REGION")
         String awsAccessKeyId = SystemBinding.getPropOrEnv("AWS_ACCESS_KEY_ID")
         String awsSecret = SystemBinding.getPropOrEnv("AWS_SECRET_ACCESS_KEY")
+
+        // Non standard AWS, for example Minio.
+        String awsEndpointURL = SystemBinding.getPropOrEnv("AWS_ENDPOINT_URL")
         if (awsAccessKeyId && awsSecret) {
             System.setProperty("aws.accessKeyId", awsAccessKeyId)
             System.setProperty("aws.secretKey", awsSecret)
@@ -57,6 +62,7 @@ class S3ClientToolFactory implements ToolFactory<AmazonS3> {
 
         AmazonS3ClientBuilder cb = AmazonS3ClientBuilder.standard()
         if (awsRegion) cb.withRegion(awsRegion)
+        if (awsEndpointURL) cb.withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(awsEndpointURL, Regions.US_EAST_1.name()))
         s3Client = cb.build()
     }
 


### PR DESCRIPTION
Minio is a s3 compatible service. It is easy to deploy a Minio service.

FYI:
https://docs.min.io/docs/how-to-use-aws-sdk-for-java-with-minio-server.html